### PR TITLE
Drop polling timer for SIGUSR1.

### DIFF
--- a/elfuse-fuse.c
+++ b/elfuse-fuse.c
@@ -54,7 +54,7 @@ elfuse_create(const char *path, mode_t mode, struct fuse_file_info *fi)
 
     /* Wait for the funcall results */
     fprintf(stderr, "CREATE request (path=%s).\n", path);
-    raise(SIGUSR1);
+    pthread_kill(emacs_thread, SIGUSR1);
     sem_wait(&request_sem);
 
     /* Got the results, see if everything's fine */
@@ -96,7 +96,7 @@ elfuse_rename(const char *oldpath, const char *newpath)
 
     /* Wait for the funcall results */
     fprintf(stderr, "RENAME request (oldpath=%s, newpath=%s).\n", oldpath, newpath);
-    raise(SIGUSR1);
+    pthread_kill(emacs_thread, SIGUSR1);
     sem_wait(&request_sem);
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
@@ -137,7 +137,7 @@ elfuse_getattr(const char *path, struct stat *stbuf)
 
     /* Wait for the funcall results */
     fprintf(stderr, "GETATTR request (path=%s)\n", path);
-    raise(SIGUSR1);
+    pthread_kill(emacs_thread, SIGUSR1);
     sem_wait(&request_sem);
 
     /* Got the results, see if everything's fine */
@@ -192,7 +192,7 @@ elfuse_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 
     /* Wait for results */
     fprintf(stderr, "READDIR request (path=%s)\n", path);
-    raise(SIGUSR1);
+    pthread_kill(emacs_thread, SIGUSR1);
     sem_wait(&request_sem);
 
     /* Got the results, see if everything's fine */
@@ -239,7 +239,7 @@ elfuse_open(const char *path, struct fuse_file_info *fi)
 
     /* Wait for results */
     fprintf(stderr, "OPEN request (path=%s)\n", path);
-    raise(SIGUSR1);
+    pthread_kill(emacs_thread, SIGUSR1);
     sem_wait(&request_sem);
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
@@ -284,7 +284,7 @@ elfuse_release(const char *path, struct fuse_file_info *fi)
 
     /* Wait for results */
     fprintf(stderr, "RELEASE request (path=%s)\n", path);
-    raise(SIGUSR1);
+    pthread_kill(emacs_thread, SIGUSR1);
     sem_wait(&request_sem);
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
@@ -330,7 +330,7 @@ elfuse_read(const char *path, char *buf, size_t size, off_t offset,
 
     /* Wait for the funcall results */
     fprintf(stderr, "READ request (path=%s, size=%ld, offset=%ld).\n", path, size, offset);
-    raise(SIGUSR1);
+    pthread_kill(emacs_thread, SIGUSR1);
     sem_wait(&request_sem);
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
@@ -379,7 +379,7 @@ elfuse_write(const char *path, const char *buf, size_t size, off_t offset,
 
     /* Wait for the funcall results */
     fprintf(stderr, "WRITE request (path=%s, size=%ld, offset=%ld).\n", path, size, offset);
-    raise(SIGUSR1);
+    pthread_kill(emacs_thread, SIGUSR1);
     sem_wait(&request_sem);
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
@@ -420,7 +420,7 @@ elfuse_truncate(const char *path, off_t size)
 
     /* Wait for the funcall results */
     fprintf(stderr, "TRUNCATE request (path=%s, size=%ld).\n", path, size);
-    raise(SIGUSR1);
+    pthread_kill(emacs_thread, SIGUSR1);
     sem_wait(&request_sem);
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
@@ -460,7 +460,7 @@ elfuse_unlink(const char *path)
 
     /* Wait for the funcall results */
     fprintf(stderr, "UNLINK request (path=%s).\n", path);
-    raise(SIGUSR1);
+    pthread_kill(emacs_thread, SIGUSR1);
     sem_wait(&request_sem);
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {

--- a/elfuse-fuse.c
+++ b/elfuse-fuse.c
@@ -55,7 +55,7 @@ elfuse_create(const char *path, mode_t mode, struct fuse_file_info *fi)
     /* Wait for the funcall results */
     fprintf(stderr, "CREATE request (path=%s).\n", path);
     pthread_kill(emacs_thread, SIGUSR1);
-    sem_wait(&request_sem);
+    while (sem_wait(&request_sem));
 
     /* Got the results, see if everything's fine */
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
@@ -97,7 +97,7 @@ elfuse_rename(const char *oldpath, const char *newpath)
     /* Wait for the funcall results */
     fprintf(stderr, "RENAME request (oldpath=%s, newpath=%s).\n", oldpath, newpath);
     pthread_kill(emacs_thread, SIGUSR1);
-    sem_wait(&request_sem);
+    while (sem_wait(&request_sem));
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
         if (elfuse_call.results.rename.code == RENAME_DONE) {
@@ -138,7 +138,7 @@ elfuse_getattr(const char *path, struct stat *stbuf)
     /* Wait for the funcall results */
     fprintf(stderr, "GETATTR request (path=%s)\n", path);
     pthread_kill(emacs_thread, SIGUSR1);
-    sem_wait(&request_sem);
+    while (sem_wait(&request_sem));
 
     /* Got the results, see if everything's fine */
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
@@ -193,7 +193,7 @@ elfuse_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
     /* Wait for results */
     fprintf(stderr, "READDIR request (path=%s)\n", path);
     pthread_kill(emacs_thread, SIGUSR1);
-    sem_wait(&request_sem);
+    while (sem_wait(&request_sem));
 
     /* Got the results, see if everything's fine */
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
@@ -240,7 +240,7 @@ elfuse_open(const char *path, struct fuse_file_info *fi)
     /* Wait for results */
     fprintf(stderr, "OPEN request (path=%s)\n", path);
     pthread_kill(emacs_thread, SIGUSR1);
-    sem_wait(&request_sem);
+    while (sem_wait(&request_sem));
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
         fprintf(stderr, "OPEN success (code=%d)\n", elfuse_call.results.open.code);
@@ -285,7 +285,7 @@ elfuse_release(const char *path, struct fuse_file_info *fi)
     /* Wait for results */
     fprintf(stderr, "RELEASE request (path=%s)\n", path);
     pthread_kill(emacs_thread, SIGUSR1);
-    sem_wait(&request_sem);
+    while (sem_wait(&request_sem));
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
         fprintf(stderr, "RELEASE success (code=%d)\n", elfuse_call.results.release.code);
@@ -331,7 +331,7 @@ elfuse_read(const char *path, char *buf, size_t size, off_t offset,
     /* Wait for the funcall results */
     fprintf(stderr, "READ request (path=%s, size=%ld, offset=%ld).\n", path, size, offset);
     pthread_kill(emacs_thread, SIGUSR1);
-    sem_wait(&request_sem);
+    while (sem_wait(&request_sem));
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
         if (elfuse_call.results.read.bytes_read >= 0) {
@@ -380,7 +380,7 @@ elfuse_write(const char *path, const char *buf, size_t size, off_t offset,
     /* Wait for the funcall results */
     fprintf(stderr, "WRITE request (path=%s, size=%ld, offset=%ld).\n", path, size, offset);
     pthread_kill(emacs_thread, SIGUSR1);
-    sem_wait(&request_sem);
+    while (sem_wait(&request_sem));
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
         fprintf(stderr, "WRITE success (size=%d)\n", elfuse_call.results.write.size);
@@ -421,7 +421,7 @@ elfuse_truncate(const char *path, off_t size)
     /* Wait for the funcall results */
     fprintf(stderr, "TRUNCATE request (path=%s, size=%ld).\n", path, size);
     pthread_kill(emacs_thread, SIGUSR1);
-    sem_wait(&request_sem);
+    while (sem_wait(&request_sem));
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
         fprintf(stderr, "TRUNCATE success (code=%d)\n", elfuse_call.results.truncate.code);
@@ -461,7 +461,7 @@ elfuse_unlink(const char *path)
     /* Wait for the funcall results */
     fprintf(stderr, "UNLINK request (path=%s).\n", path);
     pthread_kill(emacs_thread, SIGUSR1);
-    sem_wait(&request_sem);
+    while (sem_wait(&request_sem));
 
     if (elfuse_call.response_state == RESPONSE_SUCCESS) {
         fprintf(stderr, "UNLINK success (code=%d)\n", elfuse_call.results.unlink.code);

--- a/elfuse-fuse.h
+++ b/elfuse-fuse.h
@@ -17,9 +17,10 @@
 #define ELFUSE_FUSE_H
 
 #include <pthread.h>
+#include <semaphore.h>
 
-extern pthread_mutex_t elfuse_mutex;
-extern pthread_cond_t elfuse_cond_var;
+extern sem_t request_sem;
+extern sem_t init_sem;
 
 /* Init codes */
 enum elfuse_init_code_enum {

--- a/elfuse-fuse.h
+++ b/elfuse-fuse.h
@@ -21,6 +21,7 @@
 
 extern sem_t request_sem;
 extern sem_t init_sem;
+extern pthread_t emacs_thread;
 
 /* Init codes */
 enum elfuse_init_code_enum {

--- a/elfuse-module.c
+++ b/elfuse-module.c
@@ -29,6 +29,7 @@ int plugin_is_GPL_compatible;
 
 sem_t request_sem;
 sem_t init_sem;
+pthread_t emacs_thread;
 
 static bool elfuse_is_started = false;
 static pthread_t fuse_thread;
@@ -676,6 +677,7 @@ emacs_module_init (struct emacs_runtime *ert)
     nil = env->intern(env, "nil");
     t = env->intern(env, "t");
     elfuse_op_error = env->intern(env, "elfuse-op-error");
+    emacs_thread = pthread_self();
 
     emacs_value fun = env->make_function (
         env, 1, 1,


### PR DESCRIPTION
Since the signal doesn't cooperate with the condition variable, I swapped the condition variable + mutex for a semaphore. There's also a separate one-off initialization semaphore. It's a bit simpler with the semaphore, almost 40 fewer lines shorter.

The semaphore starts off at 0. When a FUSE request comes in, the FUSE thread signals the Emacs thread with SIGUSR1 and waits on the semaphore. The Emacs thread computes its value and increments the semaphore when it's done, releasing the FUSE thread to gather the result. When the FUSE thread unblocks the semaphore back to 0, ready for the next request.

It seems to work fine in my tests, but you should double check for yourself.